### PR TITLE
20 renounceoverridecostmanager improvements

### DIFF
--- a/contracts/CostManagerFactoryHelper.sol
+++ b/contracts/CostManagerFactoryHelper.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./interfaces/ICostManagerFactoryHelper.sol";
+import "./CostManagerBase.sol";
 
 // used for factory
 abstract contract CostManagerFactoryHelper is ICostManagerFactoryHelper, Ownable {
@@ -32,16 +33,17 @@ abstract contract CostManagerFactoryHelper is ICostManagerFactoryHelper, Ownable
     */
     function renounceOverrideCostManager(address instance) public onlyOwner {
         _renouncedOverrideCostManager.add(instance);
+
+        CostManagerBase(instance).overrideCostManager(address(0));
+
         emit RenouncedOverrideCostManagerForInstance(instance);
     }
     
     /** 
     * @dev instance can call this to find out whether a given address can set the cost manager contract
-    * @param account the address to test
     * @param instance the instance to test
     */
     function canOverrideCostManager(
-        address account, 
         address instance
     ) 
         external 
@@ -50,7 +52,7 @@ abstract contract CostManagerFactoryHelper is ICostManagerFactoryHelper, Ownable
         view
         returns (bool) 
     {
-        return (account == owner() && _renouncedOverrideCostManager.contains(instance));
+        return (_renouncedOverrideCostManager.contains(instance));
     }
 
     function _setCostManager(address costManager_) internal {

--- a/contracts/interfaces/ICostManagerFactoryHelper.sol
+++ b/contracts/interfaces/ICostManagerFactoryHelper.sol
@@ -3,5 +3,5 @@ pragma solidity ^0.8.0;
 
 interface ICostManagerFactoryHelper {
     
-    function canOverrideCostManager(address account, address instance) external view returns (bool);
+    function canOverrideCostManager(address instance) external view returns (bool);
 }

--- a/contracts/mocks/examples/InstanceEx1.sol
+++ b/contracts/mocks/examples/InstanceEx1.sol
@@ -18,4 +18,9 @@ contract InstanceEx1 is CostManagerHelper, OwnableUpgradeable {
         // uint256 param2 = 3;
         _accountForOperation(info, param1, param2);
     }
+
+    function setCostManager(address costManager) public {
+        _setCostManager(costManager);
+    }
+
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@intercoin/releasemanager",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@intercoin/releasemanager",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
         "@intercoin/trustedforwarder": "^1.0.1",

--- a/test/releasemanager.js
+++ b/test/releasemanager.js
@@ -334,7 +334,7 @@ describe("release manager", function () {
             await costManagerEx1.doRevert(true);
             await expect(instanceEx1WithCostManager.method1(info, param1, param2)).revertedWith('SomeError');
             //cant override
-            await expect(instanceEx1WithCostManager.overrideCostManager(ZERO_ADDRESS)).revertedWith('cannot override');
+            await expect(instanceEx1WithCostManager.overrideCostManager(ZERO_ADDRESS)).revertedWithCustomError(instanceEx1WithCostManager, 'CanNotOverride');
             
         });
 
@@ -353,13 +353,13 @@ describe("release manager", function () {
             await expect(instanceEx1WithCostManager.method1(info, param1, param2)).revertedWith('SomeError');
 
             //cant override
-            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWith('Override required by factory');
+            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWithCustomError(instanceEx1WithCostManager, 'OverrideRequired');
             //renounce overrride for instanceEx1WithCostManager
             await factoryEx1.connect(owner).renounceOverrideCostManager(instanceEx1WithCostManager.target);
 
             await expect(
                 factoryEx1.connect(owner).renounceOverrideCostManager(instanceEx1WithCostManager.target)
-            ).revertedWith('Already overrode');
+            ).revertedWithCustomError(instanceEx1WithCostManager, 'AlreadyOverrode');
         });
 
         it("shouldnt override CostManager address until factory approve", async() => {
@@ -377,7 +377,7 @@ describe("release manager", function () {
             await expect(instanceEx1WithCostManager.method1(info, param1, param2)).revertedWith('SomeError');
 
             //cant override
-            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWith('Override required by factory');
+            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWithCustomError(instanceEx1WithCostManager, 'OverrideRequired');
             //renounce overrride for instanceEx1WithCostManager
             await factoryEx1.connect(owner).renounceOverrideCostManager(instanceEx1WithCostManager.target);
             // now instance'sowner can override(removing) CostManager
@@ -406,7 +406,7 @@ describe("release manager", function () {
             // is possible to override ? - no
             expect( await factoryEx1.canOverrideCostManager(instanceEx1WithCostManager.target)).to.be.false;
             //prove it. cant override
-            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWith('Override required by factory');
+            await expect(instanceEx1WithCostManager.setCostManager(ZERO_ADDRESS)).revertedWithCustomError(instanceEx1WithCostManager, 'OverrideRequired');
             //renounce overrride for instanceEx1WithCostManager
             await factoryEx1.connect(owner).renounceOverrideCostManager(instanceEx1WithCostManager.target);
             // override is possible
@@ -440,7 +440,7 @@ describe("release manager", function () {
 
             const instanceEx1WithBadCostManager = await ethers.getContractAt("InstanceEx1",instance);
 
-            await expect(instanceEx1WithBadCostManager.method1(1, 2, 3)).revertedWith('unknown error');
+            await expect(instanceEx1WithBadCostManager.method1(1, 2, 3)).revertedWithCustomError(instanceEx1WithBadCostManager, 'UnknownError');
 
         })
 


### PR DESCRIPTION
fixed and improved logic with Cost manager
so if we have Factory(**F**) and Instance(**I**).
**F** produced **I** and transfer ownership to sender, but **F** is a deployer for **I**;
**F** can setup Costmanager for all further produced instances, and instance's owner can't remove or override Costmanager.
Finally **F** can call method 'renounceOverrideCostManager(instance)' and under hood make internal transaction to `instance.overrideCostManager(zero_address)`. After that instance's owner can set up any Costmanager as he can by calling internal method _setCostManager. like this
```solidity
function setCostManager(address costManager) public onlyOwner {
        _setCostManager(costManager);
    }
```    
Besides, 'renounceOverrideCostManager(instance)' can be called only one more time

